### PR TITLE
Convert to portfolio layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,15 +6,29 @@ import Features from "./components/Features";
 import Steps from "./components/Steps";
 import FAQ from "./components/FAQ";
 import Footer from "./components/Footer";
+import Navbar from "./components/Navbar";
+import Testimonials from "./components/Testimonials";
+import FinalSection from "./components/FinalSection";
+import Projects from "./components/Projects";
+import Stack from "./components/Stack";
+import Experience from "./components/Experience";
+import Contact from "./components/Contact";
 
 function App() {
   return (
     <div className="App">
+      <Navbar />
       <Hero />
       <About />
+      <Stack />
+      <Projects />
       <Features />
       <Steps />
+      <Experience />
+      <Testimonials />
       <FAQ />
+      <FinalSection />
+      <Contact />
       <Footer />
     </div>
   );

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import contactData from "../data/contact.json";
+import "../styles.css";
+
+const Contact = () => (
+  <section className="contact-section fade-in" id="contact">
+    <div className="contact-container">
+      <p className="contact-item">{contactData.email}</p>
+      <p className="contact-item">{contactData.phone}</p>
+      <p className="contact-item">{contactData.location}</p>
+      <div className="contact-links">
+        {contactData.social.map((item, index) => (
+          <a key={index} href={item.url} className="contact-link">
+            {item.label}
+          </a>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default Contact;

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import experienceData from "../data/experience.json";
+import "../styles.css";
+
+const Experience = () => (
+  <section className="experience-section fade-in" id="experience">
+    <div className="experience-container">
+      {experienceData.map((item, index) => (
+        <div key={index} className="experience-item">
+          <div className="experience-year">{item.year}</div>
+          <div className="experience-role">{item.role}</div>
+          <p className="experience-description">{item.description}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+);
+
+export default Experience;

--- a/src/components/FinalSection.jsx
+++ b/src/components/FinalSection.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import finalData from "../data/finalSection.json";
+import "../styles.css";
+
+const FinalSection = () => {
+  return (
+    <section className="final-section fade-in">
+      <div className="final-container">
+        <h2 className="final-title">{finalData.title}</h2>
+        <p className="final-description">{finalData.description}</p>
+        <a href={finalData.buttonLink} className="btn final-button">
+          {finalData.buttonText}
+        </a>
+      </div>
+    </section>
+  );
+};
+
+export default FinalSection;

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -3,7 +3,7 @@ import footerData from "../data/footer.json";
 
 const Footer = () => {
   return (
-    <footer className="footer-section">
+    <footer className="footer-section fade-in">
       <div className="footer-container">
         <div className="footer-brand">
           <h3 className="footer-company">{footerData.companyName}</h3>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -6,8 +6,8 @@ const Hero = () => {
   return (
     <section className="hero">
       <div className="hero-container">
-        <div className="hero-tag">{heroData.tag}</div>
-        <h1 className="hero-title">{heroData.title}</h1>
+        <div className="hero-tag">{heroData.name}</div>
+        <h1 className="hero-title">{heroData.profession}</h1>
         <p className="hero-description">{heroData.description}</p>
         <a href={heroData.buttonLink} className="hero-button">
           {heroData.buttonText}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+import navbarData from "../data/navbar.json";
+import "../styles.css";
+
+const Navbar = () => {
+  return (
+    <nav className="navbar fade-in">
+      <div className="nav-container">
+        <a href={navbarData.logoLink} className="nav-logo">
+          {navbarData.logo}
+        </a>
+        <div className="nav-links">
+          {navbarData.links.map((link, index) => (
+            <a key={index} href={link.url} className="nav-link">
+              {link.label}
+            </a>
+          ))}
+        </div>
+      </div>
+    </nav>
+  );
+};
+
+export default Navbar;

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import projectsData from "../data/projects.json";
+import "../styles.css";
+
+const Projects = () => (
+  <section className="projects-section fade-in" id="projects">
+    <div className="projects-container">
+      {projectsData.map((project, index) => (
+        <div key={index} className="project-card">
+          <img src={project.image} alt={project.title} className="project-image" />
+          <h3 className="project-title">{project.title}</h3>
+          <p className="project-description">{project.description}</p>
+          <a href={project.url} className="project-link">View Project</a>
+        </div>
+      ))}
+    </div>
+  </section>
+);
+
+export default Projects;

--- a/src/components/Stack.jsx
+++ b/src/components/Stack.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import stackData from "../data/stack.json";
+import "../styles.css";
+
+const Stack = () => (
+  <section className="stack-section fade-in" id="stack">
+    <div className="stack-container">
+      {stackData.map((item, index) => (
+        <div key={index} className="stack-item">
+          <div className="stack-icon">{item.icon}</div>
+          <div className="stack-name">{item.name}</div>
+        </div>
+      ))}
+    </div>
+  </section>
+);
+
+export default Stack;

--- a/src/components/Testimonials.jsx
+++ b/src/components/Testimonials.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import testimonialsData from "../data/testimonials.json";
+import "../styles.css";
+
+const Testimonials = () => {
+  return (
+    <section className="testimonials-section fade-in">
+      <div className="testimonials-container">
+        {testimonialsData.map((item, index) => (
+          <div key={index} className="testimonial-card">
+            <img
+              src={item.avatar}
+              alt={item.name}
+              className="testimonial-avatar"
+            />
+            <p className="testimonial-text">{item.text}</p>
+            <p className="testimonial-name">{item.name}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default Testimonials;

--- a/src/data/about.json
+++ b/src/data/about.json
@@ -1,9 +1,9 @@
 {
-  "badge": "About us",
-  "title": "Who We Are?",
-  "description": "We’re a global platform dedicated to simplifying currency exchange and cross-border transactions. Our mission is to provide individuals and businesses with an efficient, cost-effective, and secure way to manage their international finances. Trusted by thousands of users worldwide, we strive to make global business as seamless as local.",
+  "badge": "About Me",
+  "title": "Who am I?",
+  "description": "I'm a developer passionate about creating modern web experiences and learning new technologies.",
   "button": {
-    "text": "Get Started →",
+    "text": "Download CV",
     "link": "#"
   }
 }

--- a/src/data/contact.json
+++ b/src/data/contact.json
@@ -1,0 +1,9 @@
+{
+  "email": "johndoe@example.com",
+  "phone": "+1 555 123 4567",
+  "location": "Remote / Worldwide",
+  "social": [
+    { "label": "LinkedIn", "url": "https://linkedin.com" },
+    { "label": "GitHub", "url": "https://github.com" }
+  ]
+}

--- a/src/data/experience.json
+++ b/src/data/experience.json
@@ -1,0 +1,12 @@
+[
+  {
+    "year": "2024",
+    "role": "Front-end Developer at TechCorp",
+    "description": "Developed user interfaces with React and improved performance."
+  },
+  {
+    "year": "2023",
+    "role": "Full Stack Developer at StartUpX",
+    "description": "Built scalable services with Node.js and AWS." 
+  }
+]

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -1,18 +1,18 @@
 [
   {
-    "question": "How do I open an account?",
-    "answer": "You can open an account in just a few minutes by signing up online and verifying your identity."
+    "question": "Which technologies do you specialize in?",
+    "answer": "I focus on the MERN stack but enjoy exploring new tools."
   },
   {
-    "question": "Is my money safe?",
-    "answer": "Yes. We use industry-leading security protocols and your funds are insured up to the legal limit."
+    "question": "Do you take freelance projects?",
+    "answer": "Yes, I'm open to challenging freelance opportunities."
   },
   {
-    "question": "Are there any hidden fees?",
-    "answer": "No. We pride ourselves on transparency. All fees are clearly stated and there are no surprises."
+    "question": "Can you work remotely?",
+    "answer": "Absolutely, I have experience with distributed teams."
   },
   {
-    "question": "Can I send money internationally?",
-    "answer": "Absolutely. You can send and receive money globally with our fast and low-cost transfer services."
+    "question": "How can I contact you?",
+    "answer": "Use the form below or email me at johndoe@example.com."
   }
 ]

--- a/src/data/features.json
+++ b/src/data/features.json
@@ -1,17 +1,17 @@
 [
   {
-    "title": "Secure Transactions",
-    "description": "Your money is protected with bank-level encryption and fraud detection systems.",
-    "icon": "🔒"
+    "title": "Front-End Development",
+    "description": "Building responsive interfaces with React.",
+    "icon": "🖥️"
   },
   {
-    "title": "Global Transfers",
-    "description": "Send and receive money across the world in seconds, with real-time tracking.",
-    "icon": "🌍"
+    "title": "Back-End Development",
+    "description": "Creating robust APIs with Node.js and Express.",
+    "icon": "⚙️"
   },
   {
-    "title": "Multi-Currency Accounts",
-    "description": "Hold, spend, and convert multiple currencies all from one simple account.",
-    "icon": "💱"
+    "title": "UI/UX Design",
+    "description": "Designing modern experiences in Figma.",
+    "icon": "🎨"
   }
 ]

--- a/src/data/finalSection.json
+++ b/src/data/finalSection.json
@@ -1,0 +1,6 @@
+{
+  "title": "Interested in working together?",
+  "description": "Let's build amazing projects or discuss new opportunities.",
+  "buttonText": "Contact Me",
+  "buttonLink": "#contact"
+}

--- a/src/data/footer.json
+++ b/src/data/footer.json
@@ -1,11 +1,10 @@
 {
-  "companyName": "Fintech Global",
-  "description": "Empowering your financial freedom with secure and modern digital solutions.",
+  "companyName": "John Doe",
+  "description": "Full Stack Developer passionate about clean code and modern web.",
   "links": [
-    { "label": "About Us", "url": "#" },
-    { "label": "Features", "url": "#" },
-    { "label": "Pricing", "url": "#" },
-    { "label": "Contact", "url": "#" }
+    { "label": "LinkedIn", "url": "https://linkedin.com" },
+    { "label": "GitHub", "url": "https://github.com" },
+    { "label": "Email", "url": "mailto:johndoe@example.com" }
   ],
-  "copyright": "© 2025 Fintech Global. All rights reserved."
+  "copyright": "© 2025 John Doe. All rights reserved."
 }

--- a/src/data/hero.json
+++ b/src/data/hero.json
@@ -1,7 +1,7 @@
 {
-  "tag": "Currency Exchange",
-  "title": "Global. Online. Banking.",
-  "description": "We offer personal and business accounts that are easy to open",
-  "buttonText": "Get Started →",
-  "buttonLink": "#"
+  "name": "John Doe",
+  "profession": "Full Stack Developer",
+  "description": "I build scalable web applications and interactive experiences.",
+  "buttonText": "View Projects →",
+  "buttonLink": "#projects"
 }

--- a/src/data/navbar.json
+++ b/src/data/navbar.json
@@ -1,0 +1,10 @@
+{
+  "logo": "John Doe",
+  "logoLink": "#",
+  "links": [
+    {"label": "About", "url": "#about"},
+    {"label": "Projects", "url": "#projects"},
+    {"label": "Stack", "url": "#stack"},
+    {"label": "Contact", "url": "#contact"}
+  ]
+}

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -1,0 +1,20 @@
+[
+  {
+    "title": "Portfolio Website",
+    "description": "Personal site built with React and Vite.",
+    "image": "/about-default.png",
+    "url": "#"
+  },
+  {
+    "title": "E-commerce Platform",
+    "description": "Online store with custom checkout and admin dashboard.",
+    "image": "/about-default.png",
+    "url": "#"
+  },
+  {
+    "title": "Open Source Library",
+    "description": "Reusable components for fast UI development.",
+    "image": "/about-default.png",
+    "url": "#"
+  }
+]

--- a/src/data/stack.json
+++ b/src/data/stack.json
@@ -1,0 +1,6 @@
+[
+  { "name": "React", "icon": "⚛️" },
+  { "name": "Node.js", "icon": "🟢" },
+  { "name": "MongoDB", "icon": "🍃" },
+  { "name": "Docker", "icon": "🐳" }
+]

--- a/src/data/steps.json
+++ b/src/data/steps.json
@@ -1,17 +1,17 @@
 [
   {
     "step": "1",
-    "title": "Create Your Account",
-    "description": "Sign up in minutes with your email and a secure password. No paperwork required."
+    "title": "Plan",
+    "description": "Understand goals and design clean solutions."
   },
   {
     "step": "2",
-    "title": "Verify Your Identity",
-    "description": "Upload your ID and take a quick selfie to keep your account safe and compliant."
+    "title": "Build",
+    "description": "Develop responsive interfaces and scalable backends."
   },
   {
     "step": "3",
-    "title": "Start Transacting",
-    "description": "Send, receive, and manage your money globally, all in one place."
+    "title": "Launch",
+    "description": "Deploy and iterate quickly for continuous improvement."
   }
 ]

--- a/src/data/testimonials.json
+++ b/src/data/testimonials.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "Alice Johnson",
+    "text": "Working with John was a pleasure. The project was delivered on time and exceeded expectations.",
+    "avatar": "/about-default.png"
+  },
+  {
+    "name": "Mark Smith",
+    "text": "John's attention to detail and clean code made collaboration easy.",
+    "avatar": "/about-default.png"
+  }
+]

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,10 +5,18 @@
   box-sizing: border-box;
 }
 
+:root {
+  --color-bg: #000000;
+  --color-accent: #D7FB00;
+  --color-text: #F1F1F1;
+  --color-secondary: #7E7E7E;
+  --color-card: #1A1A1A;
+}
+
 body {
   font-family: 'Inter', sans-serif;
-  background-color: #f0f4ff; /* Fondo celeste claro */
-  color: #111;
+  background-color: var(--color-bg);
+  color: var(--color-text);
   line-height: 1.6;
 }
 
@@ -35,14 +43,32 @@ button {
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
 }
 
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fade-in {
+  opacity: 0;
+  animation: fadeInUp 0.8s forwards;
+}
+
 .btn {
-  background: linear-gradient(90deg, #669cf6, #4f6dfb);
-  color: white;
+  background: var(--color-accent);
+  color: var(--color-bg);
   border: none;
   padding: 10px 24px;
   border-radius: 100px;
   transition: all 0.3s ease-in-out;
   font-weight: 500;
+  display: inline-block;
+  margin-top: 1rem;
 }
 
 .btn:hover {
@@ -65,17 +91,17 @@ h2 {
 
 p {
   font-size: 1rem;
-  color: #333;
+  color: var(--color-secondary);
 }
 .hero {
-  background-color: #f4f7ff;
+  background-color: var(--color-card);
   text-align: center;
   padding: 5rem 1rem;
 }
 
 .hero-tag {
-  background: linear-gradient(90deg, #6d84f9, #87a5ff);
-  color: white;
+  background: var(--color-accent);
+  color: var(--color-bg);
   font-weight: 600;
   padding: 0.6rem 2rem;
   border-radius: 2rem;
@@ -88,18 +114,19 @@ p {
   font-size: 3rem;
   font-weight: 800;
   margin: 0;
-  color: #0f0f0f;
+  color: var(--color-text);
 }
 
 .hero-description {
-  color: #555;
+  color: var(--color-secondary);
   margin: 1rem auto 2rem;
   max-width: 600px;
   font-size: 1.1rem;
 }
 
 .hero-button {
-  background-color: #6d84f9;
+  background-color: var(--color-accent);
+  color: var(--color-bg);
   color: white;
   border: none;
   border-radius: 2rem;
@@ -124,6 +151,10 @@ p {
   text-align: left;
 }
 
+.about-description {
+  margin-bottom: 1.5rem;
+}
+
 .about-image-wrapper {
   display: flex;
   justify-content: center;
@@ -137,7 +168,7 @@ p {
 }
 .features-section {
   padding: 4rem 1rem;
-  background-color: #f8f9ff;
+  background-color: var(--color-bg);
 }
 
 .features-container {
@@ -149,7 +180,7 @@ p {
 }
 
 .feature-card {
-  background: white;
+  background: var(--color-card);
   border-radius: 16px;
   padding: 2rem;
   text-align: center;
@@ -173,11 +204,11 @@ p {
 }
 
 .feature-description {
-  color: #555;
+  color: var(--color-secondary);
   font-size: 0.95rem;
 }
 .steps-section {
-  background-color: #ffffff;
+  background-color: var(--color-bg);
   padding: 4rem 1rem;
 }
 
@@ -189,7 +220,7 @@ p {
 }
 
 .step-card {
-  background-color: #f0f4ff;
+  background-color: var(--color-card);
   padding: 2rem;
   border-radius: 14px;
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.06);
@@ -204,7 +235,7 @@ p {
 .step-number {
   font-size: 1.5rem;
   font-weight: bold;
-  color: #4c6ef5;
+  color: var(--color-accent);
   margin-bottom: 0.5rem;
 }
 
@@ -216,10 +247,10 @@ p {
 
 .step-description {
   font-size: 0.95rem;
-  color: #555;
+  color: var(--color-secondary);
 }
 .faq-section {
-  background-color: #f7f9ff;
+  background-color: var(--color-card);
   padding: 4rem 1rem;
 }
 
@@ -233,13 +264,13 @@ p {
   font-weight: 700;
   text-align: center;
   margin-bottom: 2rem;
-  color: #222;
+  color: var(--color-text);
 }
 
 .faq-item {
   margin-bottom: 1.5rem;
   padding: 1.25rem;
-  background-color: #ffffff;
+  background-color: var(--color-bg);
   border-radius: 12px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
 }
@@ -251,14 +282,15 @@ p {
 }
 
 .faq-answer {
-  color: #555;
+  color: var(--color-secondary);
   font-size: 0.95rem;
   line-height: 1.5;
 }
 .footer-section {
-  background-color: #0d0d0d;
-  color: #f1f1f1;
+  background-color: var(--color-bg);
+  color: var(--color-text);
   padding: 3rem 1rem 2rem;
+  transition: background-color 0.3s ease;
 }
 
 .footer-container {
@@ -283,7 +315,7 @@ p {
 .footer-description {
   font-size: 0.95rem;
   line-height: 1.5;
-  color: #aaa;
+  color: var(--color-secondary);
 }
 
 .footer-links {
@@ -293,19 +325,250 @@ p {
 }
 
 .footer-link {
-  color: #ccc;
+  color: var(--color-secondary);
   text-decoration: none;
   font-size: 0.95rem;
   transition: color 0.2s ease;
 }
 
 .footer-link:hover {
-  color: #ffffff;
+  color: var(--color-accent);
 }
 
 .footer-bottom {
   text-align: center;
   margin-top: 2rem;
   font-size: 0.85rem;
-  color: #777;
+  color: var(--color-secondary);
+}
+
+/* ====== NAVBAR ====== */
+.navbar {
+  background-color: var(--color-card);
+  padding: 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  transition: background-color 0.3s ease;
+}
+
+.nav-container {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.nav-logo {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--color-accent);
+}
+
+.nav-links {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.nav-link {
+  color: var(--color-text);
+  font-size: 0.95rem;
+  transition: color 0.2s ease;
+}
+
+.nav-link:hover {
+  color: var(--color-accent);
+}
+
+/* ====== TESTIMONIALS ====== */
+.testimonials-section {
+  background-color: var(--color-card);
+  color: var(--color-text);
+  padding: 4rem 1rem;
+}
+
+.testimonials-container {
+  max-width: 1000px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+}
+
+.testimonial-card {
+  background-color: var(--color-bg);
+  padding: 2rem;
+  border-radius: 1rem;
+  text-align: center;
+}
+
+.testimonial-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  margin-bottom: 1rem;
+}
+
+.testimonial-text {
+  font-size: 0.95rem;
+  margin-bottom: 0.75rem;
+}
+
+.testimonial-name {
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+/* ====== FINAL SECTION ====== */
+.final-section {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  text-align: center;
+  padding: 4rem 1rem;
+}
+
+.final-title {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.final-description {
+  margin-bottom: 1.5rem;
+  color: var(--color-secondary);
+}
+
+.final-button {
+  background: var(--color-accent);
+  color: var(--color-bg);
+}
+
+/* ====== PROJECTS ====== */
+.projects-section {
+  background-color: var(--color-bg);
+  padding: 4rem 1rem;
+}
+
+.projects-container {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.project-card {
+  background-color: var(--color-card);
+  padding: 1.5rem;
+  border-radius: 12px;
+  text-align: center;
+}
+
+.project-image {
+  width: 100%;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+}
+
+.project-title {
+  font-size: 1.25rem;
+  color: var(--color-text);
+  margin-bottom: 0.5rem;
+}
+
+.project-description {
+  color: var(--color-secondary);
+  font-size: 0.95rem;
+  margin-bottom: 0.75rem;
+}
+
+.project-link {
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+/* ====== STACK ====== */
+.stack-section {
+  background-color: var(--color-card);
+  padding: 4rem 1rem;
+}
+
+.stack-container {
+  max-width: 1000px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1.5rem;
+  text-align: center;
+}
+
+.stack-item {
+  padding: 1rem;
+}
+
+.stack-icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+  color: var(--color-accent);
+}
+
+.stack-name {
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+/* ====== EXPERIENCE ====== */
+.experience-section {
+  background-color: var(--color-bg);
+  padding: 4rem 1rem;
+}
+
+.experience-container {
+  max-width: 800px;
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.experience-item {
+  background-color: var(--color-card);
+  padding: 1.5rem;
+  border-radius: 12px;
+}
+
+.experience-year {
+  color: var(--color-accent);
+  font-weight: bold;
+}
+
+.experience-role {
+  font-size: 1.1rem;
+  color: var(--color-text);
+  margin: 0.5rem 0;
+}
+
+.experience-description {
+  color: var(--color-secondary);
+  font-size: 0.95rem;
+}
+
+/* ====== CONTACT ====== */
+.contact-section {
+  background-color: var(--color-card);
+  color: var(--color-text);
+  text-align: center;
+  padding: 4rem 1rem;
+}
+
+.contact-item {
+  margin-bottom: 1rem;
+  color: var(--color-secondary);
+}
+
+.contact-links {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.contact-link {
+  color: var(--color-accent);
 }

--- a/src/templates/LandingGeneral.jsx
+++ b/src/templates/LandingGeneral.jsx
@@ -4,15 +4,21 @@ import Features from "../components/Features";
 import Steps from "../components/Steps";
 import FAQ from "../components/FAQ";
 import Footer from "../components/Footer";
+import Navbar from "../components/Navbar";
+import Testimonials from "../components/Testimonials";
+import FinalSection from "../components/FinalSection";
 
 export default function LandingGeneral({ data }) {
   return (
     <div>
+      <Navbar data={data} />
       <Hero data={data} />
       <About data={data} />
       <Features data={data} />
       <Steps data={data} />
+      <Testimonials data={data} />
       <FAQ data={data} />
+      <FinalSection data={data} />
       <Footer data={data} />
     </div>
   );


### PR DESCRIPTION
## Summary
- set global dark theme palette
- make hero use name and profession
- add projects, stack, experience and contact sections
- convert all JSON data to personal portfolio content
- update build artifacts for Vite

## Testing
- `node node_modules/vite/bin/vite.js build`

------
https://chatgpt.com/codex/tasks/task_e_6876af8de604832eba40b311790a6a53