### PR TITLE
Fix styles for improved layout

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -12,9 +12,9 @@
   --color-4: #7ef7d0;
   --color-5: #ffffff;
 
-  --color-bg: var(--color-1);
+  --color-bg: #ffffff;
   --color-accent: var(--color-4);
-  --color-text: var(--color-5);
+  --color-text: #333333;
   --color-secondary: var(--color-3);
   --color-card: var(--color-2);
 }
@@ -51,6 +51,22 @@ button {
 
 .rounded {
   opacity: 0.95;
+}
+
+/* Simple fade-in animation used across sections */
+.fade-in {
+  opacity: 0;
+  animation: fade-in 0.8s ease-out forwards;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* Generic section padding */
+.section {
+  padding: 4rem 1rem;
 }
 
 /* ====== TÍTULOS ====== */
@@ -243,5 +259,14 @@ p {
 .nav-links {
   display: flex;
   gap: 1.5rem;
+}
+
+.nav-link {
+  color: var(--color-text);
+  transition: color 0.2s ease;
+}
+
+.nav-link:hover {
+  color: var(--color-accent);
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
   font-family: 'Inter', sans-serif;
-  background-color: black;
-  color: white;
+  background-color: white;
+  color: black;
 }


### PR DESCRIPTION
## Summary
- switch to a white background and dark default text
- add a fade-in animation and generic section padding
- style navigation links
- ensure unused global stylesheet also has white background

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68771fa5d1a0832ebe38d2760bbc1389