### PR TITLE
Fix styles for feature sections

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -10,7 +10,7 @@ const About = () => {
           <span className="badge">{aboutData.badge}</span>
           <h2 className="about-title">{aboutData.title}</h2>
           <p className="about-description">{aboutData.description}</p>
-          <a href={aboutData.button.link} className="btn primary">
+          <a href={aboutData.button.link} className="btn">
             {aboutData.button.text}
           </a>
         </div>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -9,7 +9,7 @@ const Hero = () => {
         <div className="hero-tag">{heroData.name}</div>
         <h1 className="hero-title">{heroData.profession}</h1>
         <p className="hero-description">{heroData.description}</p>
-        <a href={heroData.buttonLink} className="hero-button">
+        <a href={heroData.buttonLink} className="btn hero-button">
           {heroData.buttonText}
         </a>
       </div>

--- a/src/data/about.json
+++ b/src/data/about.json
@@ -1,7 +1,7 @@
 {
-"badge": "Sobre mí",
+  "badge": "Sobre mí",
   "title": "Conóceme",
-  "description": "Soy Álvaro Perez, estudiante avanzado de Ingeniería en Sistemas en UTN FRC. Me gusta combinar tecnología y creatividad para crear soluciones eficientes.",
+  "description": "Soy Álvaro Perez, estudiante de 4° año de Ingeniería en Sistemas en UTN FRC. Combino automatización y diseño UX/UI para optimizar procesos.",
   "button": {
     "text": "Descargar CV",
     "link": "#"

--- a/src/data/hero.json
+++ b/src/data/hero.json
@@ -1,7 +1,7 @@
 {
   "name": "Álvaro Perez",
-  "profession": "Est. Ing. en Sistemas",
-  "description": "Apasionado por la automatización, prototipado y diseño UX/UI. Manejo React, JavaScript y Python.",
+  "profession": "Estudiante de Ing. en Sistemas",
+  "description": "Apasionado por la automatización, el desarrollo web y el diseño UX/UI.",
   "buttonText": "Ver proyectos",
   "buttonLink": "#projects",
   "image": "/hero-avatar.png"

--- a/src/styles.css
+++ b/src/styles.css
@@ -12,11 +12,11 @@
   --color-4: #7ef7d0;
   --color-5: #ffffff;
 
-  --color-bg: var(--color-1);
-  --color-accent: var(--color-4);
-  --color-text: var(--color-5);
-  --color-secondary: var(--color-3);
-  --color-card: var(--color-2);
+  --color-bg: var(--color-5);
+  --color-text: #222222;
+  --color-secondary: #555555;
+  --color-accent: var(--color-1);
+  --color-card: #f5f7f9;
 }
 
 .linear-gradient {
@@ -53,6 +53,48 @@ button {
   opacity: 0.95;
 }
 
+.btn {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  border-radius: 1.5rem;
+  background-color: var(--color-accent);
+  color: var(--color-5);
+  font-weight: 600;
+  transition: background-color 0.2s ease;
+}
+
+.btn:hover {
+  background-color: var(--color-3);
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  background-color: var(--color-3);
+  color: var(--color-5);
+  border-radius: 0.5rem;
+  font-size: 0.75rem;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05rem;
+}
+
+/* Simple fade-in animation used across sections */
+.fade-in {
+  opacity: 0;
+  animation: fade-in 0.8s ease-out forwards;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* Generic section padding */
+.section {
+  padding: 4rem 1rem;
+}
+
 /* ====== TÍTULOS ====== */
 h1 {
   font-size: 3rem;
@@ -71,9 +113,13 @@ p {
   color: var(--color-secondary);
 }
 .hero {
-  background-color: var(--color-card);
+  background: linear-gradient(135deg, var(--color-2), var(--color-4));
   text-align: center;
   padding: 5rem 1rem;
+}
+.hero-container {
+  max-width: 800px;
+  margin: 0 auto;
 }
 .hero-image {
   width: 120px;
@@ -83,14 +129,16 @@ p {
 }
 
 .hero-tag {
-  background: var(--color-accent);
-  color: var(--color-bg);
-  font-weight: 600;
-  padding: 0.6rem 2rem;
-  border-radius: 2rem;
   display: inline-block;
+  padding: 0.25rem 0.75rem;
+  background-color: var(--color-3);
+  color: var(--color-5);
+  border-radius: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05rem;
+  text-transform: uppercase;
   margin-bottom: 2rem;
-  font-size: 0.9rem;
 }
 
 .hero-title {
@@ -108,16 +156,6 @@ p {
 }
 
 .hero-button {
-  background-color: var(--color-accent);
-  color: var(--color-bg);
-  border: none;
-  border-radius: 2rem;
-  padding: 0.75rem 2rem;
-  font-weight: 600;
-  font-size: 1rem;
-  cursor: pointer;
-  text-decoration: none;
-  display: inline-block;
   margin-top: 1rem;
 }
 .about-grid {
@@ -141,6 +179,16 @@ p {
 .about-image-wrapper {
   display: flex;
   justify-content: center;
+}
+
+@media (max-width: 768px) {
+  .about-grid {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+  .about-content {
+    text-align: center;
+  }
 }
 
 .about-image {
@@ -245,3 +293,302 @@ p {
   gap: 1.5rem;
 }
 
+.nav-link {
+  color: var(--color-text);
+  transition: color 0.2s ease;
+}
+
+.nav-link:hover {
+  color: var(--color-accent);
+}
+
+/* ====== FEATURES / SKILLS ====== */
+.features-section {
+  background-color: var(--color-bg);
+  padding: 4rem 1rem;
+}
+
+.features-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+}
+
+.feature-card {
+  background: var(--color-card);
+  border-radius: 16px;
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.07);
+  transition: transform 0.3s ease;
+}
+
+.feature-card:hover {
+  transform: translateY(-5px);
+}
+
+.feature-icon {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.feature-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.feature-description {
+  color: var(--color-secondary);
+  font-size: 0.95rem;
+}
+
+/* ====== STEPS ====== */
+.steps-section {
+  background-color: var(--color-bg);
+  padding: 4rem 1rem;
+}
+
+.steps-container {
+  max-width: 1000px;
+  margin: 0 auto;
+  display: grid;
+  gap: 2rem;
+}
+
+.step-card {
+  background-color: var(--color-card);
+  padding: 2rem;
+  border-radius: 14px;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.06);
+  text-align: left;
+  transition: transform 0.2s ease;
+}
+
+.step-card:hover {
+  transform: translateY(-4px);
+}
+
+.step-number {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: var(--color-accent);
+  margin-bottom: 0.5rem;
+}
+
+.step-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.step-description {
+  font-size: 0.95rem;
+  color: var(--color-secondary);
+}
+
+/* ====== TESTIMONIALS ====== */
+.testimonials-section {
+  background-color: var(--color-card);
+  color: var(--color-text);
+  padding: 4rem 1rem;
+}
+
+.testimonials-container {
+  max-width: 1000px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+}
+
+.testimonial-card {
+  background-color: var(--color-bg);
+  padding: 2rem;
+  border-radius: 1rem;
+  text-align: center;
+}
+
+.testimonial-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  margin-bottom: 1rem;
+}
+
+.testimonial-text {
+  font-size: 0.95rem;
+  margin-bottom: 0.75rem;
+}
+
+.testimonial-name {
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+/* ====== FINAL SECTION ====== */
+.final-section {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  text-align: center;
+  padding: 4rem 1rem;
+}
+
+.final-container {
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.final-title {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.final-description {
+  margin-bottom: 1.5rem;
+  color: var(--color-secondary);
+}
+
+.final-button {
+  background-color: var(--color-accent);
+  color: var(--color-5);
+}
+
+/* ====== PROJECTS ====== */
+.projects-section {
+  background-color: var(--color-bg);
+  padding: 4rem 1rem;
+}
+
+.projects-container {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.project-card {
+  background-color: var(--color-card);
+  padding: 1.5rem;
+  border-radius: 12px;
+  text-align: center;
+}
+
+.project-image {
+  width: 100%;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+}
+
+.project-title {
+  font-size: 1.25rem;
+  color: var(--color-text);
+  margin-bottom: 0.5rem;
+}
+
+.project-description {
+  color: var(--color-secondary);
+  font-size: 0.95rem;
+  margin-bottom: 0.75rem;
+}
+
+.project-link {
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+/* ====== STACK ====== */
+.stack-section {
+  background-color: var(--color-card);
+  padding: 4rem 1rem;
+}
+
+.stack-container {
+  max-width: 1000px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1.5rem;
+  text-align: center;
+}
+
+.stack-item {
+  padding: 1rem;
+}
+
+.stack-icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+  color: var(--color-accent);
+}
+
+.stack-name {
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+/* ====== EXPERIENCE ====== */
+.experience-section {
+  background-color: var(--color-bg);
+  padding: 4rem 1rem;
+}
+
+.experience-container {
+  max-width: 800px;
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.experience-item {
+  background-color: var(--color-card);
+  padding: 1.5rem;
+  border-radius: 12px;
+}
+
+.experience-year {
+  color: var(--color-accent);
+  font-weight: bold;
+}
+
+.experience-role {
+  font-size: 1.1rem;
+  color: var(--color-text);
+  margin: 0.5rem 0;
+}
+
+.experience-description {
+  color: var(--color-secondary);
+  font-size: 0.95rem;
+}
+
+/* ====== CONTACT ====== */
+.contact-section {
+  background-color: var(--color-card);
+  color: var(--color-text);
+  text-align: center;
+  padding: 4rem 1rem;
+}
+
+.contact-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.contact-item {
+  margin-bottom: 1rem;
+  color: var(--color-secondary);
+}
+
+.contact-links {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.contact-link {
+  color: var(--color-accent);
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
   font-family: 'Inter', sans-serif;
-  background-color: black;
-  color: white;
+  background-color: #ffffff;
+  color: #222222;
 }


### PR DESCRIPTION
## Summary
- add styling for features/skills grid, steps cards and other sections
- include styles for testimonials, projects, stack, experience and contact
- refine button, badge and hero layout styles
- tweak color palette for better contrast and update about/hero texts

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68771fa5d1a0832ebe38d2760bbc1389