### PR TITLE
Refactor portfolio template for easier customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Landing Template
+
+Este proyecto es una plantilla modular para portafolios personales construida con React y Vite.
+
+## Personalización
+
+Todo el contenido se encuentra en archivos JSON dentro de `src/data`. Para crear un nuevo portafolio solo debes modificar estos archivos o reemplazarlos por otros con la misma estructura.
+
+Los estilos globales se encuentran en `src/styles.css` y la paleta de colores en `src/theme.css`.
+Puedes adaptarlos o sustituirlos por tus propios estilos.
+
+## Desarrollo
+
+Instala las dependencias y ejecuta el servidor de desarrollo:
+
+```bash
+npm install
+npm run dev
+```
+
+Al construir (`npm run build`) obtendrás una versión optimizada lista para desplegar.
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,22 +12,23 @@ import FinalSection from "./components/FinalSection";
 import Projects from "./components/Projects";
 import Experience from "./components/Experience";
 import Education from "./components/Education";
+import data from './data';
 
 function App() {
   return (
     <div className="App">
-      <Navbar />
-      <Hero />
-      <About />
-      <Projects />
-      <Skills />
-      <Steps />
-      <Experience />
-      <Education />
-      <Testimonials />
-      <FAQ />
-      <FinalSection />
-      <Footer />
+      <Navbar data={data.navbar} />
+      <Hero data={data.hero} />
+      <About data={data.about} />
+      <Projects data={data.projects} />
+      <Skills data={data.skills} />
+      <Steps data={data.steps} />
+      <Experience data={data.experience} />
+      <Education data={data.education} />
+      <Testimonials data={data.testimonials} />
+      <FAQ data={data.faq} />
+      <FinalSection data={data.finalSection} />
+      <Footer data={data.footer} />
     </div>
   );
 }

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,18 +1,18 @@
 import React from "react";
-import aboutData from "../data/about.json";
+import defaultData from "../data/about.json";
 import "../styles.css";
 
-const About = () => {
+const About = ({ data = defaultData }) => {
   return (
     <section className="about-section">
       <div className="about-container">
         {/* Columna izquierda: texto */}
         <div className="about-content">
-          <span className="about-tag">{aboutData.tag}</span>
-          <h2 className="about-title">{aboutData.title}</h2>
-          <p className="about-description">{aboutData.description}</p>
-          <a href={aboutData.buttonLink} className="about-button">
-            {aboutData.buttonText}
+          <span className="about-tag">{data.tag}</span>
+          <h2 className="about-title">{data.title}</h2>
+          <p className="about-description">{data.description}</p>
+          <a href={data.buttonLink} className="about-button">
+            {data.buttonText}
           </a>
         </div>
 

--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -1,11 +1,11 @@
 import React from "react";
-import educationData from "../data/education.json";
+import defaultData from "../data/education.json";
 import "../styles.css";
 
-const Education = () => (
+const Education = ({ data = defaultData }) => (
     <section className="experience-section fade-in" id="education">
         <div className="experience-container">
-            {educationData.map((item, index) => (
+            {data.map((item, index) => (
                 <div key={index} className="experience-item">
                     <div className="experience-year">{item.year}</div>
                     <div className="experience-role">{item.title}</div>

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -1,11 +1,11 @@
 import React from "react";
-import experienceData from "../data/experience.json";
+import defaultData from "../data/experience.json";
 import "../styles.css";
 
-const Experience = () => (
+const Experience = ({ data = defaultData }) => (
   <section className="experience-section fade-in" id="experience">
     <div className="experience-container">
-      {experienceData.map((item, index) => (
+      {data.map((item, index) => (
         <div key={index} className="experience-item">
           <div className="experience-year">{item.year}</div>
           <div className="experience-role">{item.role}</div>

--- a/src/components/FAQ.jsx
+++ b/src/components/FAQ.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
-import faqData from "../data/faq.json";
+import defaultData from "../data/faq.json";
 import "../styles.css";
 
-const FAQ = () => {
+const FAQ = ({ data = defaultData }) => {
   const [openIndex, setOpenIndex] = useState(null);
 
   const toggle = (index) => {
@@ -13,7 +13,7 @@ const FAQ = () => {
     <section className="faq-section fade-in">
       <div className="faq-container">
         <h2 className="faq-title">Preguntas frecuentes</h2>
-        {faqData.map((item, index) => (
+        {data.map((item, index) => (
           <div
             key={index}
             className={`faq-item ${openIndex === index ? "open" : ""}`}

--- a/src/components/Features.jsx
+++ b/src/components/Features.jsx
@@ -1,11 +1,11 @@
 import React from "react";
-import featuresData from "../data/features.json";
+import defaultData from "../data/features.json";
 
-const Features = () => {
+const Features = ({ data = defaultData }) => {
   return (
     <section className="features-section">
       <div className="features-container">
-        {featuresData.map((feature, index) => (
+        {data.map((feature, index) => (
           <div key={index} className="feature-card">
             <div className="feature-icon">{feature.icon}</div>
             <h3 className="feature-title">{feature.title}</h3>

--- a/src/components/FinalSection.jsx
+++ b/src/components/FinalSection.jsx
@@ -1,17 +1,17 @@
 import React from "react";
-import finalData from "../data/finalSection.json";
+import defaultData from "../data/finalSection.json";
 import "../styles.css";
 
-const FinalSection = () => {
+const FinalSection = ({ data = defaultData }) => {
   return (
 
     <section className="final-section fade-in">
 
       <div className="final-container">
-        <h2 className="final-title">{finalData.title}</h2>
-        <p className="final-description">{finalData.description}</p>
-        <a href={finalData.buttonLink} className="btn final-button">
-          {finalData.buttonText}
+        <h2 className="final-title">{data.title}</h2>
+        <p className="final-description">{data.description}</p>
+        <a href={data.buttonLink} className="btn final-button">
+          {data.buttonText}
         </a>
       </div>
     </section>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import footerData from "../data/footer.json";
+import defaultData from "../data/footer.json";
 
 const icons = {
   LinkedIn: "/assets/linkedin.svg",
@@ -7,16 +7,16 @@ const icons = {
   Email: "/assets/mail.svg",
 };
 
-const Footer = () => {
+const Footer = ({ data = defaultData }) => {
   return (
     <footer className="footer-section fade-in">
       <div className="footer-container">
         <div className="footer-brand">
-          <h3 className="footer-company">{footerData.companyName}</h3>
-          <p className="footer-description">{footerData.description}</p>
+          <h3 className="footer-company">{data.companyName}</h3>
+          <p className="footer-description">{data.description}</p>
         </div>
         <div className="footer-links">
-          {footerData.links.map((link, index) => (
+          {data.links.map((link, index) => (
             <a key={index} href={link.url} className="footer-link">
               <img src={icons[link.label]} alt={link.label + " icon"} />
               {link.label}
@@ -25,7 +25,7 @@ const Footer = () => {
         </div>
       </div>
       <div className="footer-bottom">
-        <p>{footerData.copyright}</p>
+        <p>{data.copyright}</p>
       </div>
     </footer>
   );

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,9 +1,9 @@
 import React from "react";
-import heroData from "../data/hero.json";
+import defaultData from "../data/hero.json";
 import "../styles.css";
 import heroImage from "/assets/Grey_Minimalist_Business_Linkedin_Banner_1.jpeg"; // asegúrate que la imagen esté allí
 
-const Hero = () => {
+const Hero = ({ data = defaultData }) => {
   return (
     <section className="hero-split">
       <div
@@ -11,11 +11,11 @@ const Hero = () => {
         style={{ backgroundImage: `url(${heroImage})` }}
       />
       <div className="hero-card">
-        <div className="hero-tag">{heroData.name}</div>
-        <h1 className="hero-title">{heroData.profession}</h1>
-        <p className="hero-description">{heroData.description}</p>
-        <a href={heroData.buttonLink} className="btn hero-button">
-          {heroData.buttonText}
+        <div className="hero-tag">{data.name}</div>
+        <h1 className="hero-title">{data.profession}</h1>
+        <p className="hero-description">{data.description}</p>
+        <a href={data.buttonLink} className="btn hero-button">
+          {data.buttonText}
         </a>
       </div>
     </section>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,13 +1,13 @@
 import React from "react";
-import navbarData from "../data/navbar.json";
+import defaultData from "../data/navbar.json";
 import "../styles.css";
 
-const Navbar = () => {
+const Navbar = ({ data = defaultData }) => {
   return (
     <nav className="navbar glassy-navbar fade-in">
       <div className="nav-container">
         <div className="nav-links">
-          {navbarData.links.map((link, index) => (
+          {data.links.map((link, index) => (
             <a key={index} href={link.url} className="nav-pill">
               {link.label}
             </a>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,11 +1,11 @@
 import React from "react";
-import projectsData from "../data/projects.json";
+import defaultData from "../data/projects.json";
 import "../styles.css";
 
-const Projects = () => (
+const Projects = ({ data = defaultData }) => (
   <section className="projects-section fade-in" id="projects">
     <div className="projects-container">
-      {projectsData.map((project, index) => (
+      {data.map((project, index) => (
         <div key={index} className="project-card">
           <img src={project.image} alt={project.title} className="project-image" />
           <h3 className="project-title">{project.title}</h3>

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -1,11 +1,11 @@
 import React from "react";
-import skillsData from "../data/skills.json";
+import defaultData from "../data/skills.json";
 import "../styles.css";
 
-const Skills = () => (
+const Skills = ({ data = defaultData }) => (
     <section className="stack-section fade-in" id="skills">
         <div className="stack-container">
-            {skillsData.map((skill, index) => (
+            {data.map((skill, index) => (
                 <div key={index} className="stack-item">
                     <div className="stack-icon">{skill.icon}</div>
                     <div className="stack-name">{skill.title}</div>

--- a/src/components/Steps.jsx
+++ b/src/components/Steps.jsx
@@ -1,11 +1,11 @@
 import React from "react";
-import stepsData from "../data/steps.json";
+import defaultData from "../data/steps.json";
 
-const Steps = () => {
+const Steps = ({ data = defaultData }) => {
   return (
     <section className="steps-section">
       <div className="steps-container">
-        {stepsData.map((step, index) => (
+        {data.map((step, index) => (
           <div key={index} className="step-card">
             <div className="step-number">{step.step}</div>
             <h3 className="step-title">{step.title}</h3>

--- a/src/components/Testimonials.jsx
+++ b/src/components/Testimonials.jsx
@@ -1,12 +1,12 @@
 import React from "react";
-import testimonialsData from "../data/testimonials.json";
+import defaultData from "../data/testimonials.json";
 import "../styles.css";
 
-const Testimonials = () => {
+const Testimonials = ({ data = defaultData }) => {
   return (
     <section className="testimonials-section fade-in">
       <div className="testimonials-container">
-        {testimonialsData.map((item, index) => (
+        {data.map((item, index) => (
           <div key={index} className="testimonial-card">
             <img
               src={item.avatar}

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -1,0 +1,31 @@
+import about from './about.json';
+import contact from './contact.json';
+import education from './education.json';
+import experience from './experience.json';
+import faq from './faq.json';
+import features from './features.json';
+import finalSection from './finalSection.json';
+import footer from './footer.json';
+import hero from './hero.json';
+import navbar from './navbar.json';
+import projects from './projects.json';
+import skills from './skills.json';
+import steps from './steps.json';
+import testimonials from './testimonials.json';
+
+export default {
+  about,
+  contact,
+  education,
+  experience,
+  faq,
+  features,
+  finalSection,
+  footer,
+  hero,
+  navbar,
+  projects,
+  skills,
+  steps,
+  testimonials,
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
+import './theme.css'
 import './styles.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,26 +1,3 @@
-/* ====== RESET Y FUENTES BASE ====== */
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-
-:root {
-  /* Palette inspired by modern clean design */
-  --color-1: #D7FB00; /* highlight */
-  --color-2: #70CFFF; /* solo para botones o detalles */
-  --color-3: #EEF7FA; /* light card bg */
-  --color-4: #70CFFF; /* gradient helper */
-  --color-5: #FFFFFF;
-
-
-  --color-bg: var(--color-5); /* global background */
-  --color-text: #000000; /* main text */
-  --color-secondary: #555555;
-  --color-accent: var(--color-2); /* buttons */
-  --color-card: var(--color-3);
-
-}
 
 .linear-gradient {
   background: linear-gradient(0.25turn, var(--color-1), var(--color-2), var(--color-3));

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,0 +1,23 @@
+/* ====== RESET Y FUENTES BASE ====== */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  /* Palette inspired by modern clean design */
+  --color-1: #D7FB00; /* highlight */
+  --color-2: #70CFFF; /* solo para botones o detalles */
+  --color-3: #EEF7FA; /* light card bg */
+  --color-4: #70CFFF; /* gradient helper */
+  --color-5: #FFFFFF;
+
+
+  --color-bg: var(--color-5); /* global background */
+  --color-text: #000000; /* main text */
+  --color-secondary: #555555;
+  --color-accent: var(--color-2); /* buttons */
+  --color-card: var(--color-3);
+
+}


### PR DESCRIPTION
## Summary
- reorganize data exports in `src/data/index.js`
- pass data props through `App` into each component
- refactor components to accept external data with defaults
- split theme variables to `src/theme.css`
- document how to customize in new `README.md`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687943e92db8832ebffd1cca0a096abb