### PR TITLE
Improve contrast and layout across portfolio sections

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -4,21 +4,22 @@ import "../styles.css";
 
 const About = ({ data = defaultData }) => {
   return (
-    <section className="about-section" id="about">
-      <div className="about-container">
+    <section className="about-section relative" id="about">
+      <div className="absolute inset-0 bg-white/80" /> {/* mejora contraste del texto */}
+      <div className="about-container relative z-10">
         {/* Columna izquierda: texto */}
         <div className="about-content">
           <span className="about-tag">{data.tag}</span>
           <h2 className="about-title">{data.title}</h2>
           <p className="about-description">{data.description}</p>
-          <a href={data.buttonLink} className="about-button">
+          <a href={data.buttonLink} className="btn about-button"> {/* botones unificados */}
             {data.buttonText}
           </a>
         </div>
 
         {/* Columna derecha: imagen */}
         <div className="about-image">
-          <img src="/assets/about-illustration.png" alt="About Illustration" />
+          <img src="/assets/about-illustration.png" alt="About Illustration" className="w-64 h-64 rounded-full object-cover" /> {/* recorta la foto */}
         </div>
       </div>
     </section>

--- a/src/components/FinalSection.jsx
+++ b/src/components/FinalSection.jsx
@@ -5,9 +5,9 @@ import "../styles.css";
 const FinalSection = ({ data = defaultData }) => {
   return (
 
-    <section className="final-section fade-in" id="contact">
-
-      <div className="final-container">
+    <section className="final-section fade-in relative" id="contact">
+      <div className="absolute inset-0 bg-white/80" /> {/* mejora contraste del texto */}
+      <div className="final-container relative z-10">
         <h2 className="final-title">{data.title}</h2>
         <p className="final-description">{data.description}</p>
         <a href={data.buttonLink} className="btn final-button">

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -10,7 +10,7 @@ const Projects = ({ data = defaultData }) => (
           <img src={project.image} alt={project.title} className="project-image" />
           <h3 className="project-title">{project.title}</h3>
           <p className="project-description">{project.description}</p>
-          <a href={project.url} className="project-link">View Project</a>
+          <a href={project.url} className="btn project-link">View Project</a> {/* botones unificados */}
         </div>
       ))}
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -41,15 +41,15 @@ button {
 .btn {
   display: inline-block;
   padding: 0.75rem 1.5rem;
-  border-radius: 1.5rem;
-  background-color: var(--color-accent);
+  border-radius: 9999px;
+  background: linear-gradient(90deg, #3b82f6, #06b6d4); /* estilo de botones unificado */
   color: var(--color-5);
-  font-weight: 600;
-  transition: background-color 0.2s ease;
+  font-weight: 700;
+  transition: opacity 0.2s ease;
 }
 
 .btn:hover {
-  background-color: var(--color-3);
+  opacity: 0.9; /* hover claro */
 }
 
 .badge {
@@ -190,13 +190,7 @@ p {
 }
 
 .hero-button {
-  padding: 0.75rem 1.5rem;
-  background: linear-gradient(90deg, #3b82f6, #06b6d4);
-  color: white;
-  border-radius: 999px;
-  font-weight: 600;
-  text-decoration: none;
-  transition: all 0.3s ease;
+  transition: transform 0.3s ease; /* unifica estilo con .btn */
 }
 
 .hero-split {
@@ -245,7 +239,7 @@ p {
 }
 
 .hero-button:hover {
-  background: linear-gradient(90deg, #2563eb, #0ea5e9);
+  transform: scale(1.05); /* hover claro */
 }
 
 /* ANIMACIÓN SUAVE */
@@ -309,18 +303,12 @@ p {
   font-size: 1.1rem;
   line-height: 1.7;
   margin-bottom: 30px;
-  color: #333;
+  color: #222; /* mejora contraste del texto */
 }
 
 .about-button {
-  background: linear-gradient(90deg, #007bff, #00d4ff);
-  color: white;
-  padding: 12px 24px;
-  border-radius: 999px;
-  font-weight: 600;
-  text-decoration: none;
   box-shadow: 0 4px 12px rgba(0, 123, 255, 0.2);
-  transition: transform 0.2s ease;
+  transition: transform 0.2s ease; /* unifica estilo del botón */
 }
 
 .about-button:hover {
@@ -335,9 +323,17 @@ p {
 }
 
 .about-image img {
-  width: 100%;
-  max-width: 450px;
-  object-fit: contain;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%; /* recorta la foto personal */
+  object-fit: cover; /* evita deformación */
+}
+
+@media (max-width: 640px) {
+  .about-container {
+    flex-direction: column;
+    text-align: center; /* simetría en pantallas pequeñas */
+  }
 }
 
 
@@ -698,14 +694,12 @@ p {
 
 .final-description {
   margin-bottom: 1.5rem;
-  color: var(--color-secondary);
+  color: #222; /* mejora contraste del texto */
 }
 
 .final-button {
-  background: linear-gradient(90deg, #007bff, #00d4ff);
-  color: white;
   box-shadow: 0 4px 12px rgba(0, 123, 255, 0.2);
-  transition: transform 0.2s ease;
+  transition: transform 0.2s ease; /* unifica estilo del botón */
 }
 
 .final-button:hover {
@@ -724,6 +718,7 @@ p {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 2rem;
+  justify-items: center; /* centra cards */
 }
 
 .project-card {
@@ -765,20 +760,12 @@ p {
 
 
 .project-link {
-  color: var(--color-accent);
-  font-weight: 600;
+  transition: transform 0.2s ease; /* estilo de botón unificado */
   text-decoration: none;
-
-  /* 🔧 Para que parezca botón */
-  padding: 0.5rem 1rem;
-  border-radius: 999px;
-  background-color: rgba(0, 0, 0, 0.05);
-  transition: all 0.2s ease;
 }
 
 .project-link:hover {
-  background-color: var(--color-accent);
-  color: white;
+  transform: scale(1.05);
 }
 
 
@@ -795,6 +782,7 @@ p {
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 1.5rem;
   text-align: center;
+  justify-items: center; /* centra habilidades */
 }
 
 .stack-item {
@@ -826,12 +814,14 @@ p {
   flex-direction: column;
   gap: 2rem;
   position: relative;
+  align-items: center; /* alinea cronología */
 }
 
 .experience-container::before {
   content: "";
   position: absolute;
-  left: 20px;
+  left: 50%;
+  transform: translateX(-50%);
   top: 0;
   bottom: 0;
   width: 4px;
@@ -844,14 +834,16 @@ p {
   border-radius: 12px;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.06);
   position: relative;
-  margin-left: 40px;
+  width: 100%;
+  max-width: 480px;
 }
 
 .experience-item::before {
   content: "";
   position: absolute;
   top: 1.5rem;
-  left: -28px;
+  left: 50%;
+  transform: translateX(-50%);
   width: 16px;
   height: 16px;
   border-radius: 50%;


### PR DESCRIPTION
## Summary
- Enhance text contrast and unify button styling with gradient and hover
- Center project, skills, and timeline blocks for consistent symmetry
- Crop profile image to circular shape and add responsive overlays for readability

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b06858b390832e9999b96aca05c936