### PR TITLE
Improve skills grid and timeline styling with icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^5.2.1",
         "react-router-dom": "^6.22.3"
       },
       "devDependencies": {
@@ -1113,6 +1114,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^5.2.1",
     "react-router-dom": "^6.22.3"
   },
   "devDependencies": {

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -2,21 +2,44 @@ import React from "react";
 import defaultData from "../data/skills.json";
 import "../styles.css";
 
-const Skills = ({ data = defaultData }) => (
-    <section className="stack-section fade-in" id="skills">
-        <div className="stack-container">
-            {data.map((skill, index) => (
-                <div key={index} className="stack-item">
-                    <div className="stack-icon">{skill.icon}</div>
-                    <div className="stack-name">{skill.title}</div>
-                    <div className="stack-category">{skill.category}</div>
-                    <div className={`stack-level level-${skill.level.toLowerCase()}`}>
-                        {skill.level}
-                    </div>
-                </div>
-            ))}
+const titleStyle = {
+  textAlign: "center",
+  marginBottom: "24px",
+  color: "var(--color-text)",
+};
+
+const subtitleStyle = {
+  margin: "32px 0 16px",
+  textAlign: "center",
+  color: "var(--color-text)",
+};
+
+const Skills = ({ data = defaultData }) => {
+  const habilidades = data.filter((item) => item.type === "habilidad");
+  const herramientas = data.filter((item) => item.type === "herramienta");
+
+  const renderItems = (items) => (
+    <div className="stack-container">
+      {items.map((skill, index) => (
+        <div key={index} className="stack-item">
+          <div className="stack-icon">{skill.icon}</div>
+          <div className="stack-name">{skill.title}</div>
+          <div className="stack-category">{skill.category}</div>
+          <div className={`stack-level level-${skill.level.toLowerCase()}`}>{skill.level}</div>
         </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <section className="stack-section fade-in" id="skills">
+      <h2 style={titleStyle}>Competencias principales</h2>
+      <h3 style={subtitleStyle}>Habilidades</h3>
+      {renderItems(habilidades)}
+      <h3 style={subtitleStyle}>Herramientas</h3>
+      {renderItems(herramientas)}
     </section>
-);
+  );
+};
 
 export default Skills;

--- a/src/components/Steps.jsx
+++ b/src/components/Steps.jsx
@@ -1,17 +1,45 @@
 import React from "react";
+import * as FiIcons from "react-icons/fi";
 import defaultData from "../data/steps.json";
+
+const titleStyle = {
+  textAlign: "center",
+  marginBottom: "24px",
+  color: "var(--color-text)",
+};
+
+const highlight = "#CBFF00";
 
 const Steps = ({ data = defaultData }) => {
   return (
     <section className="steps-section" id="steps">
+      <h2 style={titleStyle}>Resumen de tu progreso</h2>
       <div className="steps-container">
-        {data.map((step, index) => (
-          <div key={index} className="step-card">
-            <div className="step-number">{step.step}</div>
-            <h3 className="step-title">{step.title}</h3>
-            <p className="step-description">{step.description}</p>
-          </div>
-        ))}
+        {data.map((step, index) => {
+          const Icon = step.icon ? FiIcons[step.icon] : null;
+          return (
+            <div
+              key={index}
+              className="step-card"
+              style={{ borderLeft: `4px solid ${highlight}` }}
+            >
+              <div
+                className="step-number"
+                style={{ backgroundColor: highlight }}
+              >
+                {step.step}
+              </div>
+              {Icon && (
+                <Icon
+                  className="step-icon"
+                  style={{ color: highlight, fontSize: "24px", marginBottom: "16px" }}
+                />
+              )}
+              <h3 className="step-title">{step.title}</h3>
+              <p className="step-description">{step.description}</p>
+            </div>
+          );
+        })}
       </div>
     </section>
   );

--- a/src/data/skills.json
+++ b/src/data/skills.json
@@ -1,12 +1,12 @@
 [
-  { "title": "React", "category": "Frontend", "icon": "⚛️", "level": "Avanzado" },
-  { "title": "Node.js", "category": "Backend", "icon": "🟢", "level": "Intermedio" },
-  { "title": "Python", "category": "Lenguaje", "icon": "🐍", "level": "Avanzado" },
-  { "title": "SQL", "category": "Base de Datos", "icon": "🗃️", "level": "Intermedio" },
-  { "title": "Docker", "category": "DevOps", "icon": "🐳", "level": "Básico" },
-  { "title": "Git", "category": "Control de Versiones", "icon": "🔧", "level": "Avanzado" },
-  { "title": "UX/UI", "category": "Diseño", "icon": "🎨", "level": "Intermedio" },
-  { "title": "Gestión de Mejora de Procesos", "category": "Management", "icon": "📈", "level": "Avanzado" },
-  { "title": "Trabajo en Equipo", "category": "Soft Skill", "icon": "🤝", "level": "Avanzado" },
-  { "title": "Comunicación Efectiva", "category": "Soft Skill", "icon": "🗣️", "level": "Avanzado" }
+  { "title": "React", "category": "Frontend", "icon": "⚛️", "level": "Avanzado", "type": "herramienta" },
+  { "title": "Node.js", "category": "Backend", "icon": "🟢", "level": "Intermedio", "type": "herramienta" },
+  { "title": "Python", "category": "Lenguaje", "icon": "🐍", "level": "Avanzado", "type": "herramienta" },
+  { "title": "SQL", "category": "Base de Datos", "icon": "🗃️", "level": "Intermedio", "type": "herramienta" },
+  { "title": "Docker", "category": "DevOps", "icon": "🐳", "level": "Básico", "type": "herramienta" },
+  { "title": "Git", "category": "Control de Versiones", "icon": "🔧", "level": "Avanzado", "type": "herramienta" },
+  { "title": "UX/UI", "category": "Diseño", "icon": "🎨", "level": "Intermedio", "type": "habilidad" },
+  { "title": "Gestión de Mejora de Procesos", "category": "Management", "icon": "📈", "level": "Avanzado", "type": "habilidad" },
+  { "title": "Trabajo en Equipo", "category": "Soft Skill", "icon": "🤝", "level": "Avanzado", "type": "habilidad" },
+  { "title": "Comunicación Efectiva", "category": "Soft Skill", "icon": "🗣️", "level": "Avanzado", "type": "habilidad" }
 ]

--- a/src/data/steps.json
+++ b/src/data/steps.json
@@ -2,16 +2,19 @@
   {
     "step": "1",
     "title": "Prototipado y descubrimiento",
-    "description": "Detecto necesidades y diseño centrado en el usuario."
+    "description": "Detecto necesidades y diseño centrado en el usuario.",
+    "icon": "FiSearch"
   },
   {
     "step": "2",
     "title": "Desarrollo ágil",
-    "description": "Creo un MVP funcional para validar rápidamente."
+    "description": "Creo un MVP funcional para validar rápidamente.",
+    "icon": "FiTool"
   },
   {
     "step": "3",
     "title": "Iteración continua",
-    "description": "Mejoro y optimizo en base a feedback real."
+    "description": "Mejoro y optimizo en base a feedback real.",
+    "icon": "FiRefreshCw"
   }
 ]


### PR DESCRIPTION
## Summary
- split skills into Habilidades and Herramientas with section heading
- add high-contrast timeline supporting icons
- include react-icons dependency

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b376d52b68832eaf8100dbf48d6541