### PR TITLE
feat: enable smooth section navigation

### DIFF
--- a/src/components/Career.jsx
+++ b/src/components/Career.jsx
@@ -4,30 +4,36 @@ import eduData from "../data/education.json";
 import "../styles.css";
 
 const Career = ({ experience = expData, education = eduData }) => (
-  <section className="career-section fade-in" id="career">
-    <div className="career-container">
-      <div className="career-column">
-        <h2 className="career-title">Experiencia</h2> {/* título de sección */}
-        {experience.map((item, index) => (
-          <div key={index} className="career-item">
-            <div className="career-year">{item.year}</div>
-            <div className="career-role">{item.role}</div>
-            <p className="career-description">{item.description}</p>
-          </div>
-        ))}
+  <>
+    <section className="career-section fade-in" id="experiencia">
+      <div className="career-container single">
+        <div className="career-column">
+          <h2 className="career-title">Experiencia</h2>
+          {experience.map((item, index) => (
+            <div key={index} className="career-item">
+              <div className="career-year">{item.year}</div>
+              <div className="career-role">{item.role}</div>
+              <p className="career-description">{item.description}</p>
+            </div>
+          ))}
+        </div>
       </div>
-      <div className="career-column">
-        <h2 className="career-title">Educación</h2> {/* título de sección */}
-        {education.map((item, index) => (
-          <div key={index} className="career-item">
-            <div className="career-year">{item.year}</div>
-            <div className="career-role">{item.title}</div>
-            <p className="career-description">{item.institution}</p>
-          </div>
-        ))}
+    </section>
+    <section className="career-section fade-in" id="educacion">
+      <div className="career-container single">
+        <div className="career-column">
+          <h2 className="career-title">Educación</h2>
+          {education.map((item, index) => (
+            <div key={index} className="career-item">
+              <div className="career-year">{item.year}</div>
+              <div className="career-role">{item.title}</div>
+              <p className="career-description">{item.institution}</p>
+            </div>
+          ))}
+        </div>
       </div>
-    </div>
-  </section>
+    </section>
+  </>
 );
 
 export default Career;

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,27 +1,59 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import defaultData from "../data/navbar.json";
 import "../styles.css";
 
 const Navbar = ({ data = defaultData }) => {
+  const [activeSection, setActiveSection] = useState("");
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const sections = data.links
+      .map((link) => link.url.startsWith("#") ? document.querySelector(link.url) : null)
+      .filter(Boolean);
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveSection(`#${entry.target.id}`);
+          }
+        });
+      },
+      { rootMargin: "-50% 0px -50% 0px" }
+    );
+
+    sections.forEach((sec) => observer.observe(sec));
+    return () => sections.forEach((sec) => observer.unobserve(sec));
+  }, [data.links]);
+
   const handleClick = (e, url) => {
-    if (url.startsWith('#')) {
+    if (url.startsWith("#")) {
       e.preventDefault();
       const target = document.querySelector(url);
       if (target) {
-        target.scrollIntoView({ behavior: 'smooth' });
+        target.scrollIntoView({ behavior: "smooth" });
+        setActiveSection(url);
       }
     }
+    setMenuOpen(false);
   };
 
   return (
     <nav className="navbar glassy-navbar fade-in">
       <div className="nav-container">
-        <div className="nav-links">
+        <button
+          className="nav-toggle"
+          onClick={() => setMenuOpen(!menuOpen)}
+          aria-label="Toggle navigation"
+        >
+          ☰
+        </button>
+        <div className={`nav-links ${menuOpen ? "open" : ""}`}>
           {data.links.map((link, index) => (
             <a
               key={index}
               href={link.url}
-              className="nav-pill"
+              className={`nav-pill ${activeSection === link.url ? "active" : ""}`}
               onClick={(e) => handleClick(e, link.url)}
             >
               {link.label}

--- a/src/data/navbar.json
+++ b/src/data/navbar.json
@@ -3,8 +3,8 @@
     { "label": "Sobre mí", "url": "#about" },
     { "label": "Habilidades", "url": "#skills" },
     { "label": "Proyectos", "url": "#projects" },
-    { "label": "Experiencia", "url": "#experience" },
-    { "label": "Educación", "url": "#education" },
+    { "label": "Experiencia", "url": "#experiencia" },
+    { "label": "Educación", "url": "#educacion" },
     { "label": "Contacto", "url": "#contact" }
   ]
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -462,6 +462,14 @@ p {
   gap: 1rem;
 }
 
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: var(--color-text);
+}
+
 .nav-logo {
   font-size: 1.3rem;
   font-weight: bold;
@@ -490,8 +498,13 @@ p {
 }
 
 .nav-pill:hover {
-  background-color: #dff0ff;
-  color: #007aff;
+  background-color: rgba(203, 255, 0, 0.2);
+  color: #CBFF00;
+}
+
+.nav-pill.active {
+  background-color: #CBFF00;
+  color: #000;
 }
 
 .nav-cta {
@@ -506,6 +519,27 @@ p {
 
 .nav-cta:hover {
   background: linear-gradient(90deg, #2563eb, #0ea5e9);
+}
+
+@media (max-width: 768px) {
+  .nav-container {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .nav-links {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .nav-links.open {
+    display: flex;
+  }
+
+  .nav-toggle {
+    display: block;
+  }
 }
 
 
@@ -855,6 +889,16 @@ p {
 @media (min-width: 768px) {
   .career-container {
     grid-template-columns: 1fr 1fr; /* nueva estructura en columnas para educación y experiencia */
+  }
+}
+
+.career-container.single {
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+  .career-container.single {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
## Summary
- Split career information into dedicated Experiencia and Educación sections for anchoring
- Add scroll tracking and responsive mobile menu to navbar with active link highlight
- Style active nav item with high-contrast accent and ensure mobile menu collapse

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node node_modules/vite/bin/vite.js build` *(fails: Rollup failed to resolve import "react-icons/fi")*

------
https://chatgpt.com/codex/tasks/task_e_68b37b4e6308832e877dcd352666d663