### PR TITLE
feat: add glossy navbar and project modal

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -53,14 +53,14 @@ const Navbar = ({ data = defaultData }) => {
             <a
               key={index}
               href={link.url}
-              className={`nav-pill ${activeSection === link.url ? "active" : ""}`}
+              className={`btn-nav ${activeSection === link.url ? "btn-nav--active" : ""}`}
               onClick={(e) => handleClick(e, link.url)}
             >
               {link.label}
             </a>
           ))}
         </div>
-        <a href="mailto:perezalvarozul24@gmail.com" className="nav-cta">
+        <a href="mailto:perezalvarozul24@gmail.com" className="btn-nav nav-cta">
           Escribime
         </a>
       </div>

--- a/src/components/ProjectDetail.jsx
+++ b/src/components/ProjectDetail.jsx
@@ -17,7 +17,12 @@ const ProjectDetail = () => {
       <Navbar data={data.navbar} />
       <section className="project-detail-section fade-in">
         <div className="project-detail-container">
-          <img src={project.image} alt={project.title} className="project-detail-image" />
+          <img
+            src={project.coverImage.url}
+            alt={project.coverImage.alt}
+            className="project-detail-image"
+            onError={(e) => (e.currentTarget.src = "/about-default.png")}
+          />
           <h1 className="project-detail-title">{project.title}</h1>
           <p className="project-detail-description">{project.description}</p>
           <Link to="/" className="btn project-detail-button">Volver</Link> {/* botón unificado */}

--- a/src/components/ProjectModal.jsx
+++ b/src/components/ProjectModal.jsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useRef } from "react";
+import { FaExternalLinkAlt, FaGithub, FaGoogleDrive } from "react-icons/fa";
+import "../styles.css";
+
+const ProjectModal = ({ project, onClose }) => {
+  const dialogRef = useRef(null);
+  const lastFocused = useRef(null);
+
+  useEffect(() => {
+    lastFocused.current = document.activeElement;
+    const focusable = dialogRef.current.querySelectorAll("a, button");
+    focusable[0]?.focus();
+
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") {
+        onClose();
+      } else if (e.key === "Tab") {
+        const elements = dialogRef.current.querySelectorAll("a, button");
+        if (elements.length === 0) return;
+        const first = elements[0];
+        const last = elements[elements.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      lastFocused.current && lastFocused.current.focus();
+    };
+  }, [onClose]);
+
+  const hasGallery = project.gallery && project.gallery.length > 0;
+
+  return (
+    <div className="modal-overlay" role="dialog" aria-labelledby="project-title" aria-describedby="project-description">
+      <div className="modal-content" ref={dialogRef}>
+        <button className="modal-close" onClick={onClose} aria-label="Cerrar">×</button>
+        <img
+          src={project.coverImage.url}
+          alt={project.coverImage.alt}
+          onError={(e) => (e.currentTarget.src = "/about-default.png")}
+          loading="lazy"
+        />
+        <h2 id="project-title">{project.title}</h2>
+        <p id="project-description" className="modal-description" style={{ whiteSpace: "pre-line" }}>
+          {project.description}
+        </p>
+        <div>
+          {project.tags.map((tag) => (
+            <span key={tag} className="tag-chip">
+              {tag}
+            </span>
+          ))}
+        </div>
+        {hasGallery && (
+          <div className="modal-gallery">
+            {project.gallery.map((img, i) => (
+              <img
+                key={i}
+                src={img.url}
+                alt={img.alt}
+                onError={(e) => (e.currentTarget.src = "/about-default.png")}
+                loading="lazy"
+              />
+            ))}
+          </div>
+        )}
+        <div className="modal-links">
+          {project.links.deploy && (
+            <a
+              className="btn-project"
+              href={project.links.deploy}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Deploy <FaExternalLinkAlt />
+            </a>
+          )}
+          {project.links.repo && (
+            <a
+              className="btn-project"
+              href={project.links.repo}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Repo <FaGithub />
+            </a>
+          )}
+          {project.links.drive && (
+            <a
+              className="btn-project"
+              href={project.links.drive}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Drive <FaGoogleDrive />
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectModal;

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,23 +1,44 @@
-import React from "react";
-import { Link } from "react-router-dom";
+import React, { useState } from "react";
 import defaultData from "../data/projects.json";
+import ProjectModal from "./ProjectModal";
 import "../styles.css";
 
-const Projects = ({ data = defaultData }) => (
-  <section className="projects-section fade-in" id="projects">
-    <div className="projects-container">
-      {data.map((project, index) => (
-        <div key={index} className="project-card">
-          <img src={project.image} alt={project.title} className="project-image" />
-          <h3 className="project-title">{project.title}</h3>
-          <p className="project-description">{project.description}</p>
+const Projects = ({ data = defaultData }) => {
+  const [selected, setSelected] = useState(null);
 
-          <Link to={`/project/${project.id}`} className="btn project-link">Ver proyecto</Link> {/* enlace interno a la plantilla del proyecto */}
+  const hasLinks = (links) => links.deploy || links.repo || links.drive;
 
-        </div>
-      ))}
-    </div>
-  </section>
-);
+  return (
+    <section className="projects-section fade-in" id="projects">
+      <div className="projects-container">
+        {data.map((project, index) => (
+          <div key={index} className="project-card">
+            <img
+              src={project.coverImage.url}
+              alt={project.coverImage.alt}
+              className="project-image"
+              loading="lazy"
+              onError={(e) => (e.currentTarget.src = "/about-default.png")}
+            />
+            <h3 className="project-title">{project.title}</h3>
+            <p className="project-description">{project.summary}</p>
+
+            <button
+              className="btn-project"
+              onClick={() => setSelected(project)}
+              disabled={!hasLinks(project.links)}
+              title={!hasLinks(project.links) ? "Próximamente" : undefined}
+            >
+              Ver proyecto
+            </button>
+          </div>
+        ))}
+      </div>
+      {selected && (
+        <ProjectModal project={selected} onClose={() => setSelected(null)} />
+      )}
+    </section>
+  );
+};
 
 export default Projects;

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -2,37 +2,79 @@
   {
     "id": "automatizacion-invernaderos",
     "title": "Automatización de invernaderos",
-    "description": "Sistema de sensores y control con Arduino y Python.",
-    "image": "/about-default.png"
+    "summary": "Monitoreo climático con Arduino y panel web.",
+    "description": "Plataforma integral para controlar temperatura y humedad en tiempo real. Responsable de la integración de hardware y el desarrollo del panel en React. Stack: Arduino, Python, React y Tailwind. Resultado: reducción del 35% en intervenciones manuales.",
+    "tags": ["Arduino", "React", "IoT"],
+    "coverImage": {
+      "url": "/assets/projects/automatizacion-invernaderos/cover.jpg",
+      "alt": "Sensores controlando un invernadero"
+    },
+    "gallery": [
+      { "url": "/assets/projects/automatizacion-invernaderos/shot-1.png", "alt": "Vista del panel de control" },
+      { "url": "/assets/projects/automatizacion-invernaderos/shot-2.png", "alt": "Sensores instalados en cultivo" }
+    ],
+    "links": {
+      "deploy": "https://mi-sitio.com/invernaderos",
+      "repo": "https://github.com/usuario/invernaderos",
+      "drive": "https://drive.google.com/invernaderos"
+    },
+    "meta": {
+      "role": "UX/UI + Frontend",
+      "timeline": "Mar–Jun 2024",
+      "status": "online",
+      "impact": "↑35% eficiencia, ↓20% consumo"
+    }
   },
   {
     "id": "planificador-proyectos",
     "title": "Planificador de Proyectos",
-    "description": "Herramienta colaborativa para planificación remota.",
-    "image": "/about-default.png"
-  },
-  {
-    "id": "prototipador-ux",
-    "title": "Prototipador UX",
-    "description": "Librería de componentes en Figma para diseño ágil.",
-    "image": "/about-default.png"
+    "summary": "Aplicación colaborativa para planificar tareas remotas.",
+    "description": "Herramienta SaaS que permite crear y asignar tareas con actualizaciones en tiempo real. Lideré el diseño de interacción y la implementación del frontend con React y Firebase. Se logró mejorar un 40% la coordinación de equipos distribuidos.",
+    "tags": ["React", "Firebase", "SaaS"],
+    "coverImage": {
+      "url": "/assets/projects/planificador-proyectos/cover.jpg",
+      "alt": "Tablero de tareas colaborativo"
+    },
+    "gallery": [
+      { "url": "/assets/projects/planificador-proyectos/shot-1.png", "alt": "Formulario de creación de tareas" },
+      { "url": "/assets/projects/planificador-proyectos/shot-2.png", "alt": "Calendario de planificación" }
+    ],
+    "links": {
+      "deploy": "https://mi-sitio.com/planificador",
+      "repo": "https://github.com/usuario/planificador",
+      "drive": "https://drive.google.com/planificador"
+    },
+    "meta": {
+      "role": "Frontend",
+      "timeline": "Ene–Abr 2024",
+      "status": "online",
+      "impact": "↑40% coordinación"
+    }
   },
   {
     "id": "dashboard-metricas",
     "title": "Dashboard de Métricas",
-    "description": "Visualización interactiva de indicadores clave.",
-    "image": "/about-default.png"
-  },
-  {
-    "id": "bot-automatizacion",
-    "title": "Bot de Automatización",
-    "description": "Scripts para mejorar procesos repetitivos en empresas.",
-    "image": "/about-default.png"
-  },
-  {
-    "id": "landing-optimizada",
-    "title": "Landing Optimizada",
-    "description": "Sitio liviano y responsive para campañas de marketing.",
-    "image": "/about-default.png"
+    "summary": "Visualización interactiva de indicadores clave.",
+    "description": "Dashboard web para explorar métricas de negocio con filtros dinámicos. Me encargué del diseño de UX y de la implementación con D3.js y React. Permitió una reducción del 20% en tiempo de análisis.",
+    "tags": ["React", "D3.js", "DataViz"],
+    "coverImage": {
+      "url": "/assets/projects/dashboard-metricas/cover.jpg",
+      "alt": "Pantalla de dashboard con gráficas"
+    },
+    "gallery": [
+      { "url": "/assets/projects/dashboard-metricas/shot-1.png", "alt": "Gráfico de líneas" },
+      { "url": "/assets/projects/dashboard-metricas/shot-2.png", "alt": "Panel de filtros" }
+    ],
+    "links": {
+      "deploy": "https://mi-sitio.com/dashboard",
+      "repo": "https://github.com/usuario/dashboard",
+      "drive": "https://drive.google.com/dashboard"
+    },
+    "meta": {
+      "role": "Fullstack",
+      "timeline": "Jul–Sep 2023",
+      "status": "online",
+      "impact": "↓20% tiempo de análisis"
+    }
   }
 ]

--- a/src/styles.css
+++ b/src/styles.css
@@ -443,15 +443,16 @@ p {
 
 .glassy-navbar {
   backdrop-filter: blur(10px);
-  background: rgba(255, 255, 255, 0.4);
+  background: rgba(0, 0, 0, 0.6);
   border-radius: 1.5rem;
   margin: 1rem auto;
   padding: 0.75rem 1.5rem;
   max-width: 1100px;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
   position: sticky;
   top: 0;
   z-index: 50;
+  color: #EDEDED;
 }
 
 .nav-container {
@@ -467,17 +468,14 @@ p {
   background: none;
   border: none;
   font-size: 1.5rem;
-  color: var(--color-text);
+  color: #EDEDED;
 }
 
 .nav-logo {
   font-size: 1.3rem;
   font-weight: bold;
-  color: #111;
+  color: #EDEDED;
   text-decoration: none;
-  background: linear-gradient(90deg, var(--color-2), var(--color-1));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
 }
 
 .nav-links {
@@ -486,39 +484,51 @@ p {
   flex-wrap: wrap;
 }
 
-.nav-pill {
-  background: rgba(255, 255, 255, 0.7);
-  padding: 0.45rem 1rem;
-  border-radius: 999px;
+.btn-nav {
+  background: #121212;
+  color: #EDEDED;
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 6px 14px rgba(0, 0, 0, 0.45);
   font-size: 0.95rem;
   font-weight: 500;
+  line-height: 1.2;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
   text-decoration: none;
-  color: #222;
-  transition: all 0.2s ease-in-out;
+  transition: background 0.2s ease, border 0.2s ease;
 }
 
-.nav-pill:hover {
-  background-color: rgba(203, 255, 0, 0.2);
-  color: #CBFF00;
+.btn-nav:hover {
+  background: #1A1A1A;
+  border-color: rgba(255, 255, 255, 0.12);
+  color: #FFFFFF;
 }
 
-.nav-pill.active {
-  background-color: #CBFF00;
-  color: #000;
+.btn-nav:active {
+  background: #0F0F0F;
+  color: #FFFFFF;
+}
+
+.btn-nav:focus {
+  outline: 2px solid rgba(255, 255, 255, 0.35);
+  outline-offset: 3px;
+}
+
+.btn-nav--active {
+  border-bottom: 2px solid #FFFFFF;
+}
+
+.btn-nav--disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .nav-cta {
-  padding: 0.5rem 1rem;
-  background: linear-gradient(90deg, #3b82f6, #06b6d4);
-  color: white;
-  border-radius: 999px;
-  font-weight: 600;
-  text-decoration: none;
-  transition: background 0.3s ease;
-}
-
-.nav-cta:hover {
-  background: linear-gradient(90deg, #2563eb, #0ea5e9);
+  margin-left: auto;
 }
 
 @media (max-width: 768px) {
@@ -793,14 +803,104 @@ p {
 }
 
 
-.project-link {
-  transition: transform 0.2s ease; /* estilo de botón unificado */
+.btn-project {
+  background: #111;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 4px 6px rgba(0, 0, 0, 0.45);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
   text-decoration: none;
+  transition: background 0.2s ease, transform 0.1s ease;
 }
 
-.project-link:hover {
-  transform: scale(1.05);
+.btn-project:hover {
+  background: #1B1B1B;
+}
 
+.btn-project:active {
+  background: #000;
+  transform: translateY(1px);
+}
+
+.btn-project[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ====== PROJECT MODAL ====== */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal-content {
+  background: #121212;
+  color: #EDEDED;
+  padding: 2rem;
+  border-radius: 1rem;
+  max-width: 700px;
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.6);
+  position: relative;
+}
+
+.modal-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: none;
+  border: none;
+  color: #EDEDED;
+  font-size: 1.5rem;
+}
+
+.tag-chip {
+  display: inline-block;
+  background: #1A1A1A;
+  color: #EDEDED;
+  border-radius: 9999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  margin: 0 0.25rem 0.25rem 0;
+}
+
+.modal-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.modal-description {
+  max-width: 65ch;
+  margin-top: 1rem;
+}
+
+.modal-gallery {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.modal-gallery img {
+  width: 100%;
+  max-width: 200px;
+  border-radius: 0.5rem;
 }
 
 /* ====== PROJECT DETAIL ====== */


### PR DESCRIPTION
## Summary
- restyle navbar with glossy monochrome buttons and accessible focus states
- add modal to view project details sourced from new projects.json
- introduce reusable dark glossy button styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: sh: 1: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68b37e47a170832e9614107a0c646a50