### PR TITLE
feat: redesign hero with night mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,15 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Landing CSS</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Anton&family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = { darkMode: "class" };
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,23 +1,69 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import defaultData from "../data/hero.json";
 import "../styles.css";
-import heroImage from "/assets/Grey_Minimalist_Business_Linkedin_Banner_1.jpeg"; // asegúrate que la imagen esté allí
 
+// Minimal centered hero with night mode toggle
+// Inspired by typographic layouts
 const Hero = ({ data = defaultData }) => {
+  const [theme, setTheme] = useState(
+    () => localStorage.getItem("theme") || "light"
+  );
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+  };
+
   return (
-    <section className="hero-split">
-      <div
-        className="hero-bg-image"
-        style={{ backgroundImage: `url(${heroImage})` }}
-      />
-      <div className="hero-card">
-        <div className="hero-tag">{data.name}</div>
-        <h1 className="hero-title">{data.profession}</h1>
-        <p className="hero-description">{data.description}</p>
-        <a href={data.buttonLink} className="btn hero-button w-full sm:w-auto">
-          {data.buttonText}
-        </a>
+    <section
+      role="banner"
+      className="relative flex min-h-screen flex-col items-center justify-center bg-white text-gray-900 transition-colors duration-300 dark:bg-[#111111] dark:text-white"
+    >
+      {/* Night mode toggle */}
+      <button
+        onClick={toggleTheme}
+        role="switch"
+        aria-label={
+          theme === "dark" ? "Cambiar a tema claro" : "Cambiar a tema oscuro"
+        }
+        aria-checked={theme === "dark"}
+        className="absolute right-4 top-4 flex h-11 w-11 items-center justify-center rounded-full bg-white/70 text-xl shadow backdrop-blur-sm transition hover:shadow-md focus:outline-none dark:bg-[#222] dark:text-gray-100"
+      >
+        {theme === "dark" ? "☀️" : "🌙"}
+      </button>
+
+      {/* Centered content */}
+      <div className="flex flex-col items-center justify-center space-y-3 text-center">
+        <h1 className="text-6xl font-extrabold tracking-tight sm:text-7xl">
+          {data.title}
+        </h1>
+        <h2 className="text-2xl font-semibold text-gray-500 dark:text-gray-400">
+          {data.name}
+        </h2>
+        <h3 className="text-xl text-gray-500 dark:text-gray-400">
+          {data.role}
+        </h3>
+        {data.buttonText && (
+          <a
+            href={data.buttonLink}
+            className="mt-6 inline-block rounded-full bg-gradient-to-r from-zinc-200 to-zinc-300 px-6 py-2 text-sm font-medium text-gray-900 shadow transition hover:-translate-y-0.5 hover:shadow-lg active:scale-95 dark:from-zinc-700 dark:to-zinc-600 dark:text-gray-100"
+          >
+            {data.buttonText}
+          </a>
+        )}
       </div>
+
+      {/* Bottom gradient connector */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-40 bg-gradient-to-b from-white/0 via-zinc-100/70 to-zinc-200 blur-2xl dark:from-[#11111100] dark:via-[#111111b3] dark:to-[#111111]" />
     </section>
   );
 };

--- a/src/data/hero.json
+++ b/src/data/hero.json
@@ -1,8 +1,7 @@
 {
+  "title": "PORTFOLIO",
   "name": "Álvaro Perez",
-  "profession": "Estudiante de Ing. en Sistemas",
-  "description": "Apasionado por la automatización, el desarrollo web y el diseño UX/UI.",
+  "role": "Estudiante de Ing. en Sistemas",
   "buttonText": "Ver proyectos",
-  "buttonLink": "#projects",
-  "image": "/hero-avatar.png"
+  "buttonLink": "#projects"
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -21,3 +21,11 @@
   --color-card: var(--color-3);
 
 }
+
+:root.dark {
+  --color-bg: #111111;
+  --color-text: #ffffff;
+  --color-secondary: #d1d5db;
+  --color-accent: #9ca3af;
+  --color-card: #1a1a1a;
+}


### PR DESCRIPTION
## Summary
- Rebuild hero section with centered typographic layout and call-to-action button
- Add night mode toggle with localStorage persistence
- Introduce global dark theme variables and Tailwind CDN

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68b6117089ec832e831817109b4943eb